### PR TITLE
Update GeoJSON.js

### DIFF
--- a/GeoJSON.js
+++ b/GeoJSON.js
@@ -14,32 +14,32 @@ module.exports = GeoJSON = {};
 
 GeoJSON.Geometry = {
 	'type': { type: String, required: true, enum: ["Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon"] },
-	coordinates: [Object]
+	coordinates: []
 }
 
 GeoJSON.Point = {
 	'type': { type: String, required: true, default: "Point" },
-	coordinates: [Number]
+	coordinates: []
 };
 
 GeoJSON.MultiPoint = {
 	'type': { type: String, required: true, default: "MultiPoint" },
-	coordinates: [Array]
+	coordinates: []
 };
 
 GeoJSON.MultiLineString = {
 	'type': { type: String, required: true, default: "MultiLineString" },
-	coordinates: [Array]
+	coordinates: []
 }
 
 GeoJSON.Polygon = {
 	'type': { type: String, required: true, default: "Polygon" },
-	coordinates: [Array]
+	coordinates: []
 };
 
 GeoJSON.MultiPolygon = {
 	'type': { type: String, required: true, default: "MultiPolygon" },
-	coordinates: [Array]
+	coordinates: []
 };
 
 GeoJSON.GeometryCollection = {


### PR DESCRIPTION
I was only able to use the Point. When I tried to use the Polygon, i got the following stack trace:

..\data\node_modules\mongoose\lib\schema\array.js:58
    this.caster = new caster(null, castOptions);
                  ^
TypeError: string is not a function at new SchemaArray 
..\data\node_modules\mongoose\lib\schema\array.js:58:19)
    at Function.Schema.interpretAsType 

By using the native types, I am able to avoid the ambiguity of string casting. And without including the mongoose schema for Mixed type and using object, I am able to still insert anything I want.
