### PR TITLE
ci: reduce test matrix to paired Node/MongoDB versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,13 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
-        mongodb-version: ['6.0', '7.0', '8.0']
+        include:
+          - node-version: 20.x
+            mongodb-version: '6.0'
+          - node-version: 22.x
+            mongodb-version: '7.0'
+          - node-version: 24.x
+            mongodb-version: '8.0'
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
The previous matrix ran all combinations of Node (20.x, 22.x, 24.x) × MongoDB (6.0, 7.0, 8.0), resulting in 9 concurrent jobs per CI run. This caused intermittent CI failures because Docker Hub was rate-limiting the container image pulls for the MongoDB GitHub Action — too many images were being pulled in a short window.

This PR reduces the matrix to 3 pinned pairs that align each Node LTS with its contemporary MongoDB major version:

- Node 20.x + MongoDB 6.0
- Node 22.x + MongoDB 7.0
- Node 24.x + MongoDB 8.0

This cuts job count by two-thirds while still providing meaningful coverage across the supported version range.